### PR TITLE
Override isEmpty() Method

### DIFF
--- a/vaadin-combobox-multiselect/src/main/java/org/vaadin/addons/comboboxmultiselect/ComboBoxMultiselect.java
+++ b/vaadin-combobox-multiselect/src/main/java/org/vaadin/addons/comboboxmultiselect/ComboBoxMultiselect.java
@@ -1290,6 +1290,15 @@ public class ComboBoxMultiselect extends AbstractSelect implements
 		return 0;
 	}
 	
+	public boolean isEmpty(){
+	  Object value = getValue();
+    return super.isEmpty()
+            || (value instanceof Map && ((Map<?, ?>) value)
+                    .isEmpty())
+            || (value instanceof Collection && ((Collection<?>) value)
+                    .isEmpty());
+	}
+	
 	public static interface ShowButton {
 		public boolean isShow(String filter, int page);
 	}


### PR DESCRIPTION
Override isEmpty, because super.isEmpty() returns always false after even if no value is selected, after a value has been selected and cleared.

[Detailed description with screenshots.docx](https://github.com/bonprix/vaadin-combobox-multiselect/files/311657/Detailed.description.with.screenshots.docx)
