### PR TITLE
Update ComboBoxMultiselect.java

### DIFF
--- a/vaadin-combobox-multiselect/src/main/java/org/vaadin/addons/comboboxmultiselect/ComboBoxMultiselect.java
+++ b/vaadin-combobox-multiselect/src/main/java/org/vaadin/addons/comboboxmultiselect/ComboBoxMultiselect.java
@@ -488,7 +488,7 @@ public class ComboBoxMultiselect extends AbstractSelect
 
 				if (selectedCaptions.size() > 0) {
 					String selectedCaption = "(" + selectedCaptions.size() + ") "
-							+ StringUtils.join("; ", selectedCaptions);
+							+ StringUtils.join(selectedCaptions,", ");
 
 					if (this.singleSelectionCaption != null && selectedCaptions.size() == 1) {
 						selectedCaption = this.singleSelectionCaption;

--- a/vaadin-combobox-multiselect/src/main/java/org/vaadin/addons/comboboxmultiselect/ComboBoxMultiselect.java
+++ b/vaadin-combobox-multiselect/src/main/java/org/vaadin/addons/comboboxmultiselect/ComboBoxMultiselect.java
@@ -488,7 +488,7 @@ public class ComboBoxMultiselect extends AbstractSelect
 
 				if (selectedCaptions.size() > 0) {
 					String selectedCaption = "(" + selectedCaptions.size() + ") "
-							+ StringUtils.join(selectedCaptions,", ");
+							+ StringUtils.join(selectedCaptions,"; ");
 
 					if (this.singleSelectionCaption != null && selectedCaptions.size() == 1) {
 						selectedCaption = this.singleSelectionCaption;


### PR DESCRIPTION
StringUtils.join has separator as second parameter unlike Java 8's String.join. As it is now; you get brackets.