### PR TITLE
Removed dependency from PopupButton add-on

### DIFF
--- a/vaadin-combobox-multiselect/pom.xml
+++ b/vaadin-combobox-multiselect/pom.xml
@@ -125,13 +125,6 @@
 			<scope>provided</scope>
 		</dependency>
 		
-		<!-- popupbutton -->
-		<dependency>
-			<groupId>org.vaadin.addons</groupId>
-			<artifactId>popupbutton</artifactId>
-			<version>2.6.0</version>
-		</dependency>
-		
 		<!-- This can be replaced with TestNG or some other test framework supported by the surefire plugin -->
 		<dependency>
 			<groupId>junit</groupId>


### PR DESCRIPTION
Hi,

it seems vaadin-combobox-multiselect doesn't actually depend on org.vaadin.addons:popupbutton (project compiles and demo UI runs after removing the dependency); including it in the classpath causes VPopupButton widget to be compiled in the widgetset.

Thank you,

lorenzo
