### PR TITLE
migrating to v7 compatibility classes (fixes #48)

### DIFF
--- a/vaadin-combobox-multiselect-demo/pom.xml
+++ b/vaadin-combobox-multiselect-demo/pom.xml
@@ -9,7 +9,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<vaadin.version>7.5.10</vaadin.version>
+		<vaadin.version>8.1.4</vaadin.version>
 		<vaadin.plugin.version>${vaadin.version}</vaadin.plugin.version>
 	</properties>
 	   
@@ -98,6 +98,18 @@
 			<artifactId>vaadin-themes</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>com.vaadin</groupId>
+			<artifactId>vaadin-compatibility-themes</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.vaadin</groupId>
+			<artifactId>vaadin-client</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.vaadin</groupId>
+			<artifactId>vaadin-compatibility-client</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>javax.servlet</groupId>
 			<artifactId>javax.servlet-api</artifactId>
 			<version>3.0.1</version>
@@ -159,7 +171,7 @@
 				<artifactId>vaadin-maven-plugin</artifactId>
 				<version>${vaadin.plugin.version}</version>
 				<configuration>
-					<extraJvmArgs>-Xmx512M -Xss1024k</extraJvmArgs>
+					<extraJvmArgs>-Xmx1g -Xss1024k</extraJvmArgs>
 					<webappDirectory>${basedir}/src/main/webapp/VAADIN/widgetsets</webappDirectory>
 					<hostedWebapp>${basedir}/src/main/webapp/VAADIN/widgetsets</hostedWebapp>
 					<noServer>true</noServer>
@@ -184,9 +196,9 @@
 			</plugin>
 
 			<plugin>
-				<groupId>org.mortbay.jetty</groupId>
+				<groupId>org.eclipse.jetty</groupId>
 				<artifactId>jetty-maven-plugin</artifactId>
-				<version>8.1.10.v20130312</version>
+				<version>9.3.16.v20170120</version>
 				<configuration>
 					<webApp>
 						<contextPath>/</contextPath>

--- a/vaadin-combobox-multiselect-demo/src/main/java/org/vaadin/addons/demo/DemoUI.java
+++ b/vaadin-combobox-multiselect-demo/src/main/java/org/vaadin/addons/demo/DemoUI.java
@@ -15,19 +15,19 @@ import javax.servlet.annotation.WebServlet;
 import com.vaadin.annotations.Theme;
 import com.vaadin.annotations.Title;
 import com.vaadin.annotations.VaadinServletConfiguration;
-import com.vaadin.data.util.BeanItemContainer;
+import com.vaadin.v7.data.util.BeanItemContainer;
 import com.vaadin.server.ThemeResource;
 import com.vaadin.server.UserError;
 import com.vaadin.server.VaadinRequest;
 import com.vaadin.server.VaadinServlet;
 import com.vaadin.ui.Button;
-import com.vaadin.ui.ComboBox;
+import com.vaadin.v7.ui.ComboBox;
 import com.vaadin.ui.CssLayout;
-import com.vaadin.ui.HorizontalLayout;
-import com.vaadin.ui.Label;
+import com.vaadin.v7.ui.HorizontalLayout;
+import com.vaadin.v7.ui.Label;
 
 import com.vaadin.ui.UI;
-import com.vaadin.ui.VerticalLayout;
+import com.vaadin.v7.ui.VerticalLayout;
 import com.vaadin.ui.Button.ClickEvent;
 import com.vaadin.ui.Button.ClickListener;
 

--- a/vaadin-combobox-multiselect-demo/src/main/java/org/vaadin/addons/demo/theme/ValoThemeUI.java
+++ b/vaadin-combobox-multiselect-demo/src/main/java/org/vaadin/addons/demo/theme/ValoThemeUI.java
@@ -1,9 +1,9 @@
 package org.vaadin.addons.demo.theme;
 
-import com.vaadin.data.Container.Hierarchical;
-import com.vaadin.data.Item;
-import com.vaadin.data.util.HierarchicalContainer;
-import com.vaadin.data.util.IndexedContainer;
+import com.vaadin.v7.data.Container.Hierarchical;
+import com.vaadin.v7.data.Item;
+import com.vaadin.v7.data.util.HierarchicalContainer;
+import com.vaadin.v7.data.util.IndexedContainer;
 import com.vaadin.event.Action;
 import com.vaadin.event.Action.Handler;
 import com.vaadin.server.Resource;

--- a/vaadin-combobox-multiselect-demo/src/main/resources/org/vaadin/addons/demo/DemoWidgetSet.gwt.xml
+++ b/vaadin-combobox-multiselect-demo/src/main/resources/org/vaadin/addons/demo/DemoWidgetSet.gwt.xml
@@ -31,6 +31,8 @@
 
 
     <inherits name="com.vaadin.DefaultWidgetSet" />
+    
+    <inherits name="com.vaadin.v7.Vaadin7WidgetSet" />
 
     <inherits name="org.vaadin.hene.popupbutton.widgetset.PopupbuttonWidgetset" />
 </module>

--- a/vaadin-combobox-multiselect/pom.xml
+++ b/vaadin-combobox-multiselect/pom.xml
@@ -22,7 +22,7 @@
     	<maven.javadoc.skip>true</maven.javadoc.skip>
     	
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<vaadin.version>7.5.10</vaadin.version>
+		<vaadin.version>8.1.4</vaadin.version>
 		<vaadin.plugin.version>${vaadin.version}</vaadin.plugin.version>
     	
 	</properties>
@@ -89,7 +89,17 @@
 		</dependency>
 		<dependency>
 			<groupId>com.vaadin</groupId>
+			<artifactId>vaadin-compatibility-server</artifactId>
+			<version>${vaadin.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.vaadin</groupId>
 			<artifactId>vaadin-client-compiled</artifactId>
+			<version>${vaadin.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.vaadin</groupId>
+			<artifactId>vaadin-compatibility-client-compiled</artifactId>
 			<version>${vaadin.version}</version>
 		</dependency>
 		<!--
@@ -115,7 +125,18 @@
 		</dependency>
 		<dependency>
 			<groupId>com.vaadin</groupId>
+			<artifactId>vaadin-compatibility-client</artifactId>
+			<version>${vaadin.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.vaadin</groupId>
 			<artifactId>vaadin-themes</artifactId>
+			<version>${vaadin.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.vaadin</groupId>
+			<artifactId>vaadin-compatibility-themes</artifactId>
 			<version>${vaadin.version}</version>
 		</dependency>
 		<dependency>
@@ -129,7 +150,7 @@
 		<dependency>
 			<groupId>org.vaadin.addons</groupId>
 			<artifactId>popupbutton</artifactId>
-			<version>2.6.0</version>
+			<version>3.0.0</version>
 		</dependency>
 		
 		<!-- This can be replaced with TestNG or some other test framework supported by the surefire plugin -->
@@ -150,8 +171,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.0</version>
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 

--- a/vaadin-combobox-multiselect/src/main/java/org/vaadin/addons/comboboxmultiselect/ComboBoxMultiselect.java
+++ b/vaadin-combobox-multiselect/src/main/java/org/vaadin/addons/comboboxmultiselect/ComboBoxMultiselect.java
@@ -14,13 +14,13 @@ import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
 
-import com.vaadin.data.Container;
-import com.vaadin.data.Item;
-import com.vaadin.data.Validator.InvalidValueException;
-import com.vaadin.data.util.BeanItemContainer;
-import com.vaadin.data.util.converter.Converter.ConversionException;
-import com.vaadin.data.util.filter.SimpleStringFilter;
-import com.vaadin.event.FieldEvents;
+import com.vaadin.v7.data.Container;
+import com.vaadin.v7.data.Item;
+import com.vaadin.v7.data.Validator.InvalidValueException;
+import com.vaadin.v7.data.util.BeanItemContainer;
+import com.vaadin.v7.data.util.converter.Converter.ConversionException;
+import com.vaadin.v7.data.util.filter.SimpleStringFilter;
+import com.vaadin.v7.event.FieldEvents;
 import com.vaadin.event.FieldEvents.BlurEvent;
 import com.vaadin.event.FieldEvents.BlurListener;
 import com.vaadin.event.FieldEvents.FocusEvent;
@@ -28,9 +28,9 @@ import com.vaadin.event.FieldEvents.FocusListener;
 import com.vaadin.server.PaintException;
 import com.vaadin.server.PaintTarget;
 import com.vaadin.server.Resource;
-import com.vaadin.shared.ui.combobox.ComboBoxConstants;
-import com.vaadin.shared.ui.combobox.FilteringMode;
-import com.vaadin.ui.AbstractSelect;
+import com.vaadin.v7.shared.ui.combobox.ComboBoxConstants;
+import com.vaadin.v7.shared.ui.combobox.FilteringMode;
+import com.vaadin.v7.ui.AbstractSelect;
 
 /**
  * A filtering dropdown multi-select. Items are filtered based on user input,
@@ -226,7 +226,7 @@ public class ComboBoxMultiselect extends AbstractSelect
 	@SuppressWarnings("unchecked")
 	@Override
 	protected void setValue(Object newFieldValue, boolean repaintIsNotNeeded, boolean ignoreReadOnly)
-			throws com.vaadin.data.Property.ReadOnlyException, ConversionException, InvalidValueException {
+			throws com.vaadin.v7.data.Property.ReadOnlyException, ConversionException, InvalidValueException {
 		if (isMultiSelect()) {
 			Container container = getContainerDataSource();
 			if (!(container instanceof BeanItemContainer) && container instanceof Indexed) {
@@ -1091,28 +1091,9 @@ public class ComboBoxMultiselect extends AbstractSelect
 		addListener(BlurEvent.EVENT_ID, BlurEvent.class, listener, BlurListener.blurMethod);
 	}
 
-	/**
-	 * @deprecated As of 7.0, replaced by {@link #addBlurListener(BlurListener)}
-	 **/
-	@Override
-	@Deprecated
-	public void addListener(BlurListener listener) {
-		addBlurListener(listener);
-	}
-
 	@Override
 	public void removeBlurListener(BlurListener listener) {
 		removeListener(BlurEvent.EVENT_ID, BlurEvent.class, listener);
-	}
-
-	/**
-	 * @deprecated As of 7.0, replaced by
-	 *             {@link #removeBlurListener(BlurListener)}
-	 **/
-	@Override
-	@Deprecated
-	public void removeListener(BlurListener listener) {
-		removeBlurListener(listener);
 	}
 
 	@Override
@@ -1120,29 +1101,9 @@ public class ComboBoxMultiselect extends AbstractSelect
 		addListener(FocusEvent.EVENT_ID, FocusEvent.class, listener, FocusListener.focusMethod);
 	}
 
-	/**
-	 * @deprecated As of 7.0, replaced by
-	 *             {@link #addFocusListener(FocusListener)}
-	 **/
-	@Override
-	@Deprecated
-	public void addListener(FocusListener listener) {
-		addFocusListener(listener);
-	}
-
 	@Override
 	public void removeFocusListener(FocusListener listener) {
 		removeListener(FocusEvent.EVENT_ID, FocusEvent.class, listener);
-	}
-
-	/**
-	 * @deprecated As of 7.0, replaced by
-	 *             {@link #removeFocusListener(FocusListener)}
-	 **/
-	@Override
-	@Deprecated
-	public void removeListener(FocusListener listener) {
-		removeFocusListener(listener);
 	}
 
 	/**

--- a/vaadin-combobox-multiselect/src/main/java/org/vaadin/addons/comboboxmultiselect/client/ComboBoxMultiselectConnector.java
+++ b/vaadin-combobox-multiselect/src/main/java/org/vaadin/addons/comboboxmultiselect/client/ComboBoxMultiselectConnector.java
@@ -22,12 +22,12 @@ import com.vaadin.client.ApplicationConnection;
 import com.vaadin.client.Paintable;
 import com.vaadin.client.UIDL;
 import com.vaadin.client.VConsole;
-import com.vaadin.client.ui.AbstractFieldConnector;
+import com.vaadin.v7.client.ui.AbstractFieldConnector;
 import com.vaadin.client.ui.SimpleManagedLayout;
 import com.vaadin.shared.ui.Connect;
-import com.vaadin.shared.ui.combobox.ComboBoxConstants;
-import com.vaadin.shared.ui.combobox.ComboBoxState;
-import com.vaadin.shared.ui.combobox.FilteringMode;
+import com.vaadin.v7.shared.ui.combobox.ComboBoxConstants;
+import com.vaadin.v7.shared.ui.combobox.ComboBoxState;
+import com.vaadin.v7.shared.ui.combobox.FilteringMode;
 
 @SuppressWarnings("serial")
 @Connect(ComboBoxMultiselect.class)

--- a/vaadin-combobox-multiselect/src/main/java/org/vaadin/addons/comboboxmultiselect/client/ComboBoxMultiselectState.java
+++ b/vaadin-combobox-multiselect/src/main/java/org/vaadin/addons/comboboxmultiselect/client/ComboBoxMultiselectState.java
@@ -8,7 +8,7 @@ import org.vaadin.addons.comboboxmultiselect.ComboBoxMultiselect.SelectedCaption
  * 
  * @author Thorben von Hacht (bonprix Handelsgesellschaft mbH)
  */
-import com.vaadin.shared.AbstractFieldState;
+import com.vaadin.v7.shared.AbstractFieldState;
 
 public class ComboBoxMultiselectState extends AbstractFieldState {
     {

--- a/vaadin-combobox-multiselect/src/main/java/org/vaadin/addons/comboboxmultiselect/client/VComboBoxMultiselect.java
+++ b/vaadin-combobox-multiselect/src/main/java/org/vaadin/addons/comboboxmultiselect/client/VComboBoxMultiselect.java
@@ -64,7 +64,7 @@ import com.vaadin.client.WidgetUtil;
 import com.vaadin.client.ui.Field;
 import com.vaadin.client.ui.Icon;
 import com.vaadin.client.ui.SubPartAware;
-import com.vaadin.client.ui.VCheckBox;
+import com.vaadin.v7.client.ui.VCheckBox;
 import com.vaadin.client.ui.VLazyExecutor;
 import com.vaadin.client.ui.VOverlay;
 import com.vaadin.client.ui.aria.AriaHelper;
@@ -76,7 +76,7 @@ import com.vaadin.client.ui.menubar.MenuItem;
 import com.vaadin.shared.AbstractComponentState;
 import com.vaadin.shared.EventId;
 import com.vaadin.shared.ui.ComponentStateUtil;
-import com.vaadin.shared.ui.combobox.FilteringMode;
+import com.vaadin.v7.shared.ui.combobox.FilteringMode;
 import com.vaadin.shared.util.SharedUtil;
 
 /**
@@ -283,7 +283,7 @@ public class VComboBoxMultiselect extends Composite
 		 * Default constructor
 		 */
 		SuggestionPopup() {
-			super(true, false, true);
+			super(true, false);
 			debug("VFS.SP: constructor()");
 			setOwner(VComboBoxMultiselect.this);
 			this.menu = new SuggestionMenu();

--- a/vaadin-combobox-multiselect/src/main/resources/org/vaadin/addons/comboboxmultiselect/WidgetSet.gwt.xml
+++ b/vaadin-combobox-multiselect/src/main/resources/org/vaadin/addons/comboboxmultiselect/WidgetSet.gwt.xml
@@ -3,7 +3,7 @@
 	<!-- WS Compiler: manually edited -->
 
 	<!-- Inherit DefaultWidgetSet -->
-	<inherits name="com.vaadin.DefaultWidgetSet" /> 
+	<inherits name="com.vaadin.v7.Vaadin7WidgetSet" /> 
 
 	<!-- Widget styles in public -directory -->
 	<stylesheet src="vaadin-combobox-multiselect/comboboxmultiselect.css"/>


### PR DESCRIPTION
Migrating to compatibility classes (`com.vaadin.v7.*`)
Migrating to Java 8 (as Vaadin 8 requires Java 8)