### PR TITLE
Fixed calculation of number of items in ComboboxMultiselectConnector#refreshData

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ src/main/webapp/VAADIN/widgetsets/*
 .project
 */.settings/
 *.settings
+
+# Intellij
+*.iml
+.idea/

--- a/vaadin-combobox-multiselect-addon/src/main/java/org/vaadin/addons/client/ComboBoxMultiselectConnector.java
+++ b/vaadin-combobox-multiselect-addon/src/main/java/org/vaadin/addons/client/ComboBoxMultiselectConnector.java
@@ -266,7 +266,7 @@ public class ComboBoxMultiselectConnector extends AbstractListingConnector
 		updateCurrentPage();
 
 		int start = getWidget().currentPage * getWidget().pageLength;
-		int end = getWidget().pageLength > 0 ? start + getWidget().pageLength : getDataSource().size();
+		int end = getWidget().pageLength > 0 ? start + Math.min(getDataSource().size(), getWidget().pageLength) : getDataSource().size();
 
 		getWidget().currentSuggestions.clear();
 


### PR DESCRIPTION
When filtering the combobox in a way that less elements than pagelength are shown, it was not possible to select elements and there were a lot of calls to ComboBoxMultiselectConnector#refreshData() and ComboBoxMultiselectConnector#dataAvailable()

There was an error in the computation of the "end" value in refreshData() for lists with less elements than the given pageLength. After applying those changes, selection is possible after filtering and the unnecessary method calls are eliminated.

This possibly fixes #57 as well.