### PR TITLE
fix selection on last page if the amount of items is not divisible by page length

### DIFF
--- a/vaadin-combobox-multiselect-addon/src/main/java/org/vaadin/addons/client/ComboBoxMultiselectConnector.java
+++ b/vaadin-combobox-multiselect-addon/src/main/java/org/vaadin/addons/client/ComboBoxMultiselectConnector.java
@@ -288,9 +288,6 @@ implements HasRequiredIndicator, HasDataSource, SimpleManagedLayout, HasErrorInd
     private void updateSuggestions(final int start, final int end) {
         for (int i = start; i < end; ++i) {
             final JsonObject row = getDataSource().getRow(i);
-            if (row == null) {
-                getDataSource().ensureAvailability(start, end);
-            }
             if (row != null) {
                 final String key = AbstractListingConnector.getRowKey(row);
                 final String caption = row.getString(DataCommunicatorConstants.NAME);

--- a/vaadin-combobox-multiselect-addon/vaadin-combobox-multiselect.iml
+++ b/vaadin-combobox-multiselect-addon/vaadin-combobox-multiselect.iml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_8">
+    <output url="file://$MODULE_DIR$/target/classes" />
+    <output-test url="file://$MODULE_DIR$/target/test-classes" />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/main/resources" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
+      <excludeFolder url="file://$MODULE_DIR$/target" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="Maven: com.vaadin:vaadin-server:8.1.5" level="project" />
+    <orderEntry type="library" name="Maven: com.vaadin:vaadin-sass-compiler:0.9.13" level="project" />
+    <orderEntry type="library" name="Maven: org.w3c.css:sac:1.3" level="project" />
+    <orderEntry type="library" name="Maven: com.vaadin.external.flute:flute:1.3.0.gg2" level="project" />
+    <orderEntry type="library" name="Maven: com.vaadin:vaadin-shared:8.1.5" level="project" />
+    <orderEntry type="library" name="Maven: org.jsoup:jsoup:1.8.3" level="project" />
+    <orderEntry type="library" name="Maven: com.vaadin.external:gentyref:1.2.0.vaadin1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.vaadin:vaadin-client:8.1.5" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.google.gwt:gwt-elemental:2.8.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.google.gwt:gwt-user:2.8.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.google.jsinterop:jsinterop-annotations:1.0.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.google.jsinterop:jsinterop-annotations:sources:1.0.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: javax.validation:validation-api:1.0.0.GA" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: javax.validation:validation-api:sources:1.0.0.GA" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: javax.servlet:javax.servlet-api:3.1.0" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.commons:commons-lang3:3.6" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: junit:junit:4.8.1" level="project" />
+  </component>
+</module>


### PR DESCRIPTION
Selecting items on the last page was broken because of call to DataSource.ensureAvailability, where the second parameter must not exceed the size of the available data.