### PR TITLE
FW-1065 [FIX] bug in BeanItemComboBoxMultiselect filter usage

### DIFF
--- a/vaadin-combobox-multiselect-addon/src/main/java/org/vaadin/addons/ComboBoxMultiselect.java
+++ b/vaadin-combobox-multiselect-addon/src/main/java/org/vaadin/addons/ComboBoxMultiselect.java
@@ -198,6 +198,7 @@ implements FieldEvents.BlurNotifier, FieldEvents.FocusNotifier, HasFilterableDat
         @Override
         public void blur() {
             ComboBoxMultiselect.this.sortingSelection = Collections.unmodifiableCollection(getSelectedItems());
+            setFilter("");
             getDataProvider().refreshAll();
         }
 


### PR DESCRIPTION
Description:
Once set filter into BeanItemComboBoxMultiselect can not be cleared via source code, only user interaction with GUI can. Regular user describes the problem as software bug on the application and on the place where he have managed to reproduce the problem by simple usage of the problematic combobox.

Pre-requirements:
1. Only if the user put something into the filter the bug can be reproduced.

Steps to reproduce:
1. View Enter. There is active BeanItemComboBoxMultiSelect.
2. Type something valid into filter and narrow the scope. Exact match is not decisive. Post into binder or not is not relevant;
3. Choose something from the filtered items;
4. Navigate to other view and return to the tested view.
5. Try to select something from the ComboboxMultisect. Bug is reproduced. You will see that there are presented only previously filtered values.
6. To continue to use the combobox normally user can enter some data sa new filter data and delete the value after that and
all then all data is available.

Consequences:
If applications relies on the selected data or try to apply some business logic that is dependable on selected items.
In the state where user can not select anything because is filtered but push the button "select all",
then may occur null pointer exception in ComboBoxMultiselect.class on 720 row.